### PR TITLE
Now BMCIP, Username, Password are not hardcoded anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ The way it works is by running a set of scripts that interact with the hardware 
 
 The [app/](./app/) directory contains the FakeFish application. Inside the [custom_scripts](./app/custom_scripts/) folder we need to create the following scripts:
 
-|Script|What should it do?|Script parameters|
-|------|------------------|-----------------|
-|`poweron.sh`|Power on the server|`$1` BMC IP, `$2` USERNAME, `$3` PASSWORD|
-|`poweroff.sh`|Power off the server|`$1` BMC IP, `$2` USERNAME, `$3` PASSWORD|
-|`bootfromcdonce.sh`|Set server to boot from virtual CD once|`$1` BMC IP, `$2` USERNAME, `$3` PASSWORD|
-|`mountcd.sh`|Mount the iso received in the server's virtual CD|`$1` BMC IP, `$2` USERNAME, `$3` PASSWORD, `$4` ISO FILE URL|
-|`unmountcd.sh`|Unmount the iso from the server's virtual CD|`$1` BMC IP, `$2` USERNAME, `$3` PASSWORD|
+|Script|What should it do?|Env Vars|Script parameters|
+|------|------------------|--------|-----------------|
+|`poweron.sh`|Power on the server|BMC_ENDPOINT BMC_USERNAME BMC_PASSWORD|None|
+|`poweroff.sh`|Power off the server|BMC_ENDPOINT BMC_USERNAME BMC_PASSWORD|None|
+|`bootfromcdonce.sh`|Set server to boot from virtual CD once|BMC_ENDPOINT BMC_USERNAME BMC_PASSWORD|None|
+|`mountcd.sh`|Mount the iso received in the server's virtual CD|BMC_ENDPOINT BMC_USERNAME BMC_PASSWORD| `$1` ISO FILE URL|
+|`unmountcd.sh`|Unmount the iso from the server's virtual CD|BMC_ENDPOINT BMC_USERNAME BMC_PASSWORD|None|
 
 The script names must match above naming, you can check the [dell_scripts](./dell_scripts/) folder to find example scripts with the correct naming.
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
 
 The way it works is by running a set of scripts that interact with the hardware using vendor tools/other methods while exposing a fake RedFish API that Metal3 can query.
 
-The [app/](./app/) directory contains the FakeFish application. Inside the `app` directory we can find the [custom_scripts](./app/custom_scripts/) folder where we need to create scripts:
+The [app/](./app/) directory contains the FakeFish application. Inside the [custom_scripts](./app/custom_scripts/) folder we need to create the following scripts:
 
-|Script|What should it do?|
-|------|----------------|
-|`poweron.sh`|Power on the server|
-|`poweroff.sh`|Power off the server|
-|`bootfromcdonce.sh`|Set server to boot from virtual CD once|
-|`mountcd.sh`|Mount the iso received in the server's virtual CD|
-|`unmountcd.sh`|Unmount the iso from the server's virtual CD|
+|Script|What should it do?|Script parameters|
+|------|------------------|-----------------|
+|`poweron.sh`|Power on the server|`$1` BMC IP, `$2` USERNAME, `$3` PASSWORD|
+|`poweroff.sh`|Power off the server|`$1` BMC IP, `$2` USERNAME, `$3` PASSWORD|
+|`bootfromcdonce.sh`|Set server to boot from virtual CD once|`$1` BMC IP, `$2` USERNAME, `$3` PASSWORD|
+|`mountcd.sh`|Mount the iso received in the server's virtual CD|`$1` BMC IP, `$2` USERNAME, `$3` PASSWORD, `$4` ISO FILE URL|
+|`unmountcd.sh`|Unmount the iso from the server's virtual CD|`$1` BMC IP, `$2` USERNAME, `$3` PASSWORD|
 
 The script names must match above naming, you can check the [dell_scripts](./dell_scripts/) folder to find example scripts with the correct naming.
 
@@ -39,23 +39,23 @@ A [Containerfile](./custom_scripts/Containerfile) is included, so users can buil
 
 You need a FakeFish process for each server you plan to install. Think of FakeFish like if it was a custom implementation of a BMC for that specific server.
 
-Since you will be potentially running multiple FakeFish instances, you will make use of an environment variable to configure in which port a given FakeFish instance listens on. On top of that, you need to do a bind mount for the folder containing the scripts for managing that specific server.
+Since you will be potentially running multiple FakeFish instances, you will make use of an environment variable to configure in which port a given FakeFish instance listens on and another one to configure which BMC IP it provides service to. On top of that, you can do a bind mount for the folder containing the scripts for managing that specific server or use the scripts inside the container image.
 
 An example can be found below:
 
 > **NOTE**: Every container is mapped to a single BMC, but if more hosts are required, different ports can be used (9001, 9002,...)
 
-```sh
-podman run -p 9000:9000 -e PORT=9000 -v $PWD/dell_scripts:/opt/fakefish/custom_scripts:z quay.io/mavazque/fakefish:v0
+~~~sh
+podman run -p 9000:9000 -e PORT=9000 -e BMC_IP=172.20.10.10 -v $PWD/dell_scripts:/opt/fakefish/custom_scripts:z quay.io/mavazque/fakefish:v0
 
 sudo firewall-cmd --add-port=9000/tcp
-```
+~~~
 
 Then, in the `install-config.yaml` file, it is required to specify the IP where the container is running instead of the 'real' BMC:
 
-```yaml
+~~~yaml
 bmcAddress: redfish-virtualmedia://192.168.1.10:9000/redfish/v1/Systems/1
-```
+~~~
 
 ## Logs
 
@@ -63,8 +63,8 @@ In a successful execution you should see something like this in the logs:
 
 - Starting FakeFish
 
-    ```sh
-    $ podman run -p 9000:9000 -e PORT=9000 -v $PWD/dell_scripts:/opt/fakefish/custom_scripts:z quay.io/mavazque/fakefish:v0
+    ~~~sh
+    $ podman run -p 9000:9000 -e PORT=9000 -e BMC_IP=172.20.10.10 -v $PWD/dell_scripts:/opt/fakefish/custom_scripts:z quay.io/mavazque/fakefish:v0
 
      * Serving Flask app 'fakefish' (lazy loading)
      * Environment: production
@@ -74,11 +74,11 @@ In a successful execution you should see something like this in the logs:
      * Running on all addresses.
        WARNING: This is a development server. Do not use it in a production deployment.
      * Running on https://10.19.3.25:9000/ (Press CTRL+C to quit)
-    ```
+    ~~~
 
 - Provisioning Logs
 
-    ```sh
+    ~~~sh
     10.19.3.23 - - [20/Apr/2022 13:17:09] "GET /redfish/v1/Systems/1 HTTP/1.1" 200 -
     10.19.3.23 - - [20/Apr/2022 13:17:09] "GET /redfish/v1/Systems/1 HTTP/1.1" 200 -
     10.19.3.23 - - [20/Apr/2022 13:17:09] "GET /redfish/v1/Systems/1/BIOS HTTP/1.1" 404 -
@@ -140,11 +140,11 @@ In a successful execution you should see something like this in the logs:
 
     10.19.3.23 - - [20/Apr/2022 13:19:04] "POST /redfish/v1/Systems/1/Actions/ComputerSystem.Reset HTTP/1.1" 204 -
     10.19.3.23 - - [20/Apr/2022 13:19:05] "GET /redfish/v1/Systems/1 HTTP/1.1" 200 -
-    ```
+    ~~~
 
 - Deprovisioning Logs
 
-    ```sh
+    ~~~sh
     10.19.3.23 - - [20/Apr/2022 13:23:29] "GET /redfish/v1/Systems/1 HTTP/1.1" 200 -
     10.19.3.23 - - [20/Apr/2022 13:23:29] "GET /redfish/v1/Managers/1 HTTP/1.1" 200 -
     10.19.3.23 - - [20/Apr/2022 13:23:29] "GET /redfish/v1/Managers/1/VirtualMedia HTTP/1.1" 200 -
@@ -167,5 +167,4 @@ In a successful execution you should see something like this in the logs:
 
     10.19.3.23 - - [20/Apr/2022 13:24:09] "POST /redfish/v1/Systems/1/Actions/ComputerSystem.Reset HTTP/1.1" 204 -
     10.19.3.23 - - [20/Apr/2022 13:24:10] "GET /redfish/v1/Systems/1 HTTP/1.1" 200 -
-
-    ```
+    ~~~

--- a/dell_scripts/bootfromcdonce.sh
+++ b/dell_scripts/bootfromcdonce.sh
@@ -2,13 +2,14 @@
 
 #### IMPORTANT: This script is only meant to show how to implement required scripts to make custom hardware compatible with FakeFish. Dell hardware is supported by the `idrac-virtualmedia` provider in Metal3.
 #### This script has to set the server's boot to once from cd and return 0 if operation succeeded, 1 otherwise
-BMC_ENDPOINT=${1}
-USERNAME=${2}
-PASSWORD=${3}
+#### You will get the following vars as environment vars
+#### BMC_ENDPOINT - Has the BMC IP
+#### BMC_USERNAME - Has the username configured in the BMH/InstallConfig and that is used to access BMC_ENDPOINT
+#### BMC_PASSWORD - Has the password configured in the BMH/InstallConfig and that is used to access BMC_ENDPOINT
 
-/opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${USERNAME} -p ${PASSWORD} set iDRAC.VirtualMedia.BootOnce 1
+/opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${BMC_USERNAME} -p ${BMC_PASSWORD} set iDRAC.VirtualMedia.BootOnce 1
 if [ $? -eq 0 ]; then
-  /opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${USERNAME} -p ${PASSWORD} set iDRAC.ServerBoot.FirstBootDevice VCD-DVD
+  /opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${BMC_USERNAME} -p ${BMC_PASSWORD} set iDRAC.ServerBoot.FirstBootDevice VCD-DVD
   if [ $? -eq 0 ]; then
     exit 0
   else

--- a/dell_scripts/bootfromcdonce.sh
+++ b/dell_scripts/bootfromcdonce.sh
@@ -2,10 +2,13 @@
 
 #### IMPORTANT: This script is only meant to show how to implement required scripts to make custom hardware compatible with FakeFish. Dell hardware is supported by the `idrac-virtualmedia` provider in Metal3.
 #### This script has to set the server's boot to once from cd and return 0 if operation succeeded, 1 otherwise
+BMC_ENDPOINT=${1}
+USERNAME=${2}
+PASSWORD=${3}
 
-/opt/dell/srvadmin/bin/idracadm7 -r 192.168.1.10 -u root -p calvin set iDRAC.VirtualMedia.BootOnce 1
+/opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${USERNAME} -p ${PASSWORD} set iDRAC.VirtualMedia.BootOnce 1
 if [ $? -eq 0 ]; then
-  /opt/dell/srvadmin/bin/idracadm7 -r 192.168.1.10 -u root -p calvin set iDRAC.ServerBoot.FirstBootDevice VCD-DVD
+  /opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${USERNAME} -p ${PASSWORD} set iDRAC.ServerBoot.FirstBootDevice VCD-DVD
   if [ $? -eq 0 ]; then
     exit 0
   else

--- a/dell_scripts/mountcd.sh
+++ b/dell_scripts/mountcd.sh
@@ -4,15 +4,18 @@
 #### This script has to mount the iso in the server's virtualmedia and return 0 if operation succeeded, 1 otherwise
 #### Note: Iso image to mount will be received as the first argument ($1)
 
-ISO=${1}
+BMC_ENDPOINT=${1}
+USERNAME=${2}
+PASSWORD=${3}
+ISO=${4}
 
 # Disconnect image just in case
-/opt/dell/srvadmin/bin/idracadm7 -r 192.168.1.10 -u root -p calvin remoteimage -d
+/opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${USERNAME} -p ${PASSWORD} remoteimage -d
 
 # Connect image
-/opt/dell/srvadmin/bin/idracadm7 -r 192.168.1.10 -u root -p calvin remoteimage -c -l ${ISO}
+/opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${USERNAME} -p ${PASSWORD} remoteimage -c -l ${ISO}
 
-if ! /opt/dell/srvadmin/bin/idracadm7 -r 192.168.1.10 -u root -p calvin remoteimage -s | grep ${ISO}; then
+if ! /opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${USERNAME} -p ${PASSWORD} remoteimage -s | grep ${ISO}; then
   exit 1
 fi
 

--- a/dell_scripts/mountcd.sh
+++ b/dell_scripts/mountcd.sh
@@ -3,19 +3,20 @@
 #### IMPORTANT: This script is only meant to show how to implement required scripts to make custom hardware compatible with FakeFish. Dell hardware is supported by the `idrac-virtualmedia` provider in Metal3.
 #### This script has to mount the iso in the server's virtualmedia and return 0 if operation succeeded, 1 otherwise
 #### Note: Iso image to mount will be received as the first argument ($1)
+#### You will get the following vars as environment vars
+#### BMC_ENDPOINT - Has the BMC IP
+#### BMC_USERNAME - Has the username configured in the BMH/InstallConfig and that is used to access BMC_ENDPOINT
+#### BMC_PASSWORD - Has the password configured in the BMH/InstallConfig and that is used to access BMC_ENDPOINT
 
-BMC_ENDPOINT=${1}
-USERNAME=${2}
-PASSWORD=${3}
-ISO=${4}
+ISO=${1}
 
 # Disconnect image just in case
-/opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${USERNAME} -p ${PASSWORD} remoteimage -d
+/opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${BMC_USERNAME} -p ${BMC_PASSWORD} remoteimage -d
 
 # Connect image
-/opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${USERNAME} -p ${PASSWORD} remoteimage -c -l ${ISO}
+/opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${BMC_USERNAME} -p ${BMC_PASSWORD} remoteimage -c -l ${ISO}
 
-if ! /opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${USERNAME} -p ${PASSWORD} remoteimage -s | grep ${ISO}; then
+if ! /opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${BMC_USERNAME} -p ${BMC_PASSWORD} remoteimage -s | grep ${ISO}; then
   exit 1
 fi
 

--- a/dell_scripts/poweroff.sh
+++ b/dell_scripts/poweroff.sh
@@ -2,11 +2,12 @@
 
 #### IMPORTANT: This script is only meant to show how to implement required scripts to make custom hardware compatible with FakeFish. Dell hardware is supported by the `idrac-virtualmedia` provider in Metal3.
 #### This script has to poweroff the server and return 0 if operation succeeded, 1 otherwise
-BMC_ENDPOINT=${1}
-USERNAME=${2}
-PASSWORD=${3}
+#### You will get the following vars as environment vars
+#### BMC_ENDPOINT - Has the BMC IP
+#### BMC_USERNAME - Has the username configured in the BMH/InstallConfig and that is used to access BMC_ENDPOINT
+#### BMC_PASSWORD - Has the password configured in the BMH/InstallConfig and that is used to access BMC_ENDPOINT
 
-/opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${USERNAME} -p ${PASSWORD} serveraction powerdown
+/opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${BMC_USERNAME} -p ${BMC_PASSWORD} serveraction powerdown
 if [ $? -eq 0 ]; then
   exit 0
 else

--- a/dell_scripts/poweroff.sh
+++ b/dell_scripts/poweroff.sh
@@ -2,8 +2,11 @@
 
 #### IMPORTANT: This script is only meant to show how to implement required scripts to make custom hardware compatible with FakeFish. Dell hardware is supported by the `idrac-virtualmedia` provider in Metal3.
 #### This script has to poweroff the server and return 0 if operation succeeded, 1 otherwise
+BMC_ENDPOINT=${1}
+USERNAME=${2}
+PASSWORD=${3}
 
-/opt/dell/srvadmin/bin/idracadm7 -r 192.168.1.10 -u root -p calvin serveraction powerdown
+/opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${USERNAME} -p ${PASSWORD} serveraction powerdown
 if [ $? -eq 0 ]; then
   exit 0
 else

--- a/dell_scripts/poweron.sh
+++ b/dell_scripts/poweron.sh
@@ -2,11 +2,12 @@
 
 #### IMPORTANT: This script is only meant to show how to implement required scripts to make custom hardware compatible with FakeFish. Dell hardware is supported by the `idrac-virtualmedia` provider in Metal3.
 #### This script has to poweron the server and return 0 if operation succeeded, 1 otherwise
-BMC_ENDPOINT=${1}
-USERNAME=${2}
-PASSWORD=${3}
+#### You will get the following vars as environment vars
+#### BMC_ENDPOINT - Has the BMC IP
+#### BMC_USERNAME - Has the username configured in the BMH/InstallConfig and that is used to access BMC_ENDPOINT
+#### BMC_PASSWORD - Has the password configured in the BMH/InstallConfig and that is used to access BMC_ENDPOINT
 
-/opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${USERNAME} -p ${PASSWORD} serveraction powerup
+/opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${BMC_USERNAME} -p ${BMC_PASSWORD} serveraction powerup
 if [ $? -eq 0 ]; then
   exit 0
 else

--- a/dell_scripts/poweron.sh
+++ b/dell_scripts/poweron.sh
@@ -2,8 +2,11 @@
 
 #### IMPORTANT: This script is only meant to show how to implement required scripts to make custom hardware compatible with FakeFish. Dell hardware is supported by the `idrac-virtualmedia` provider in Metal3.
 #### This script has to poweron the server and return 0 if operation succeeded, 1 otherwise
+BMC_ENDPOINT=${1}
+USERNAME=${2}
+PASSWORD=${3}
 
-/opt/dell/srvadmin/bin/idracadm7 -r 192.168.1.10 -u root -p calvin serveraction powerup
+/opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${USERNAME} -p ${PASSWORD} serveraction powerup
 if [ $? -eq 0 ]; then
   exit 0
 else

--- a/dell_scripts/unmountcd.sh
+++ b/dell_scripts/unmountcd.sh
@@ -2,9 +2,12 @@
 
 #### IMPORTANT: This script is only meant to show how to implement required scripts to make custom hardware compatible with FakeFish. Dell hardware is supported by the `idrac-virtualmedia` provider in Metal3.
 #### This script has to unmount the iso from the server's virtualmedia and return 0 if operation succeeded, 1 otherwise
+BMC_ENDPOINT=${1}
+USERNAME=${2}
+PASSWORD=${3}
 
 # Disconnect image
-/opt/dell/srvadmin/bin/idracadm7 -r 192.168.1.10 -u root -p calvin remoteimage -d
+/opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${USERNAME} -p ${PASSWORD} remoteimage -d
 if [ $? -eq 0 ]; then
   exit 0
 else

--- a/dell_scripts/unmountcd.sh
+++ b/dell_scripts/unmountcd.sh
@@ -2,12 +2,13 @@
 
 #### IMPORTANT: This script is only meant to show how to implement required scripts to make custom hardware compatible with FakeFish. Dell hardware is supported by the `idrac-virtualmedia` provider in Metal3.
 #### This script has to unmount the iso from the server's virtualmedia and return 0 if operation succeeded, 1 otherwise
-BMC_ENDPOINT=${1}
-USERNAME=${2}
-PASSWORD=${3}
+#### You will get the following vars as environment vars
+#### BMC_ENDPOINT - Has the BMC IP
+#### BMC_USERNAME - Has the username configured in the BMH/InstallConfig and that is used to access BMC_ENDPOINT
+#### BMC_PASSWORD - Has the password configured in the BMH/InstallConfig and that is used to access BMC_ENDPOINT
 
 # Disconnect image
-/opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${USERNAME} -p ${PASSWORD} remoteimage -d
+/opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${BMC_USERNAME} -p ${BMC_PASSWORD} remoteimage -d
 if [ $? -eq 0 ]; then
   exit 0
 else


### PR DESCRIPTION
This commit adds more flexibility.

Now scripts will receive the destination BMC IP, username, and password via parameters.

The BMC_IP needs to be specified via an environment variable when fakefish starts.
Username and password will be read from the Authorization HTTP header sent by Ironic.

Signed-off-by: Mario Vazquez <mavazque@redhat.com>