### PR TITLE
Supermicro Containerfile builds with wrong directory

### DIFF
--- a/supermicro_scripts/Containerfile
+++ b/supermicro_scripts/Containerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /opt/fakefish/
 COPY app/fakefish.py app/cert.pem* app/cert.key* /opt/fakefish/
 
 ADD app/templates /opt/fakefish/templates
-ADD dell_scripts /opt/fakefish/custom_scripts
+ADD supermicro_scripts /opt/fakefish/custom_scripts
 
 WORKDIR /opt/fakefish/
 
@@ -21,4 +21,4 @@ RUN chown -R 1024 /opt/fakefish/
 
 USER 1024
 
-ENTRYPOINT ["/usr/bin/python3", "-u", "/opt/fakefish/fakefish.py"] 
+ENTRYPOINT ["/usr/bin/python3", "-u", "/opt/fakefish/fakefish.py"]


### PR DESCRIPTION
The Containerfile builds using the dell scripts, instead of supermicro