### PR TITLE
Fix grep command in mountcd.sh for Dell nodes

### DIFF
--- a/dell_scripts/mountcd.sh
+++ b/dell_scripts/mountcd.sh
@@ -16,7 +16,7 @@ ISO=${1}
 # Connect image
 /opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${BMC_USERNAME} -p ${BMC_PASSWORD} remoteimage -c -l ${ISO}
 
-if ! /opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${BMC_USERNAME} -p ${BMC_PASSWORD} remoteimage -s | grep ${ISO}; then
+if ! /opt/dell/srvadmin/bin/idracadm7 -r ${BMC_ENDPOINT} -u ${BMC_USERNAME} -p ${BMC_PASSWORD} remoteimage -s | grep -F ${ISO}; then
   exit 1
 fi
 


### PR DESCRIPTION
When using an ISO URL that contains an IPv6 address including brackets, those brackets are interpreted by grep as part of a regexp, causing the mountcd.sh script to fail.

If we run "grep -F", the ISO string will be taken as a literal, which is more in line with the expected outcome.